### PR TITLE
Fix -includedir parameter handling: match directory names, not full directory paths

### DIFF
--- a/FF/Program.cs
+++ b/FF/Program.cs
@@ -307,7 +307,7 @@ namespace FastFind
                             String subDirectory = Path.Combine(directory, w32FindData.cFileName);
                             if (Options.IncludeDirectories)
                             {
-                                if (IsNameMatch(subDirectory))
+                                if (IsNameMatch(w32FindData.cFileName))
                                 {
                                     Interlocked.Increment(ref totalMatches);
                                     QueueConsoleWriteLine(subDirectory);


### PR DESCRIPTION
When using -includedir paramater and searching with the exact directory name, e.g. 'bin', the program doesn't return matching directory. The workaround is to search for '*bin*' as that will match the path of the directory. However, I don't think the intended behavior is to match paths, but rather to match directory names. This change fixes that.